### PR TITLE
chore: change titleSmall typography default line height from lg to 2xl

### DIFF
--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -44,7 +44,7 @@ const styles = {
   titleSmall: {
     size: 'xl',
     weight: '400',
-    lineHeight: FontSizes.lg,
+    lineHeight: FontSizes['2xl'],
     fontFamily: serif,
   },
   subheader: { size: 'lg', weight: '400', fontFamily: serif },


### PR DESCRIPTION
change made due to text overlap when titleSmall variant Typography occurs over several lines