### PR TITLE
Fix/empty button tabbable

### DIFF
--- a/src/components/Expandable/Expandable.tsx
+++ b/src/components/Expandable/Expandable.tsx
@@ -80,7 +80,7 @@ export const Expandable = ({
     <Container>
       <HeaderContainer onClick={handleToggle} isOpen={isOpen}>
         {header}
-        {indicator && <Button>{indicator}</Button>}
+        {indicator && <Button role="button">{indicator}</Button>}
       </HeaderContainer>
       <ContentContainer isOpen={expandedState} height={height} ref={ref}>
         {children}

--- a/src/pages/governance/public-document-archives.tsx
+++ b/src/pages/governance/public-document-archives.tsx
@@ -49,7 +49,7 @@ export default function Governance() {
                   <Expandable
                     indicator={<BiChevronRight color="black" size={48} />}
                     header={
-                      <Typography variant="labelTitle" as="h4">
+                      <Typography variant="labelTitle" as="h3">
                         {fymeet.fy}
                       </Typography>
                     }
@@ -82,7 +82,7 @@ export default function Governance() {
                   <Expandable
                     indicator={<BiChevronRight color="black" size={48} />}
                     header={
-                      <Typography variant="labelTitle" as="h4">
+                      <Typography variant="labelTitle" as="h3">
                         {fyminutes.fy}
                       </Typography>
                     }


### PR DESCRIPTION
buttons that only have icons are still considered empty, therefore need to state role 