### PR TITLE
fix: mobile devices automatically capitalize the first character of i…

### DIFF
--- a/src/pages/ccc/cultural-grads/[id].tsx
+++ b/src/pages/ccc/cultural-grads/[id].tsx
@@ -44,7 +44,7 @@ export default function CGCGrad() {
   const { isMobile } = useBreakpoint();
 
   let searchInputHandler = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearchInput(e.target.value);
+    setSearchInput(e.target.value.toLowerCase());
   };
 
   const getJotformSubmissions = useCallback(async () => {


### PR DESCRIPTION
…nput entries

since we automatically set all items to lowercase, it will never include a match because .includes is case-sensitive therefore, we must set search input query to lowercase as well so that it can match regardless of whether query is in uppercase or lowercase